### PR TITLE
Changed the behavior of some lists in the frontmatter

### DIFF
--- a/ita.cls
+++ b/ita.cls
@@ -1245,14 +1245,14 @@
 %===============================================================================
 \renewcommand*{\l@figure}{\@dottedtocline{1}{0cm}{1cm}}
 \def\FigureITA@dottedtocline#1#2#3#4#5{\begingroup
-  \def\numberline##1{\hb@xt@\@tempdima{\itafigurenamebabel~##1 --\hfil}}%
+  \def\numberline##1{\hb@xt@\@tempdima{\itafigurenamebabel~##1\hfill--\hspace{0.8em}}}%
   \@dottedtocline{#1}{#2}{#3}{#4}{#5}%
   \endgroup}
 \def\TableITA@dottedtocline#1#2#3#4#5{\begingroup
-  \def\numberline##1{\hb@xt@\@tempdima{\itatablenamebabel~##1 --\hfil}}%
+  \def\numberline##1{\hb@xt@\@tempdima{\itatablenamebabel~##1\hfill--\hspace{0.8em}}}%
   \@dottedtocline{#1}{#2}{#3}{#4}{#5}%
   \endgroup}
-% faz a lista de figuras e de tabelas usarem as novas verõoes dos \dottedtocline
+% faz a lista de figuras e de tabelas usarem as novas verões dos \dottedtocline
 \renewcommand*\l@figure{\FigureITA@dottedtocline{1}{0cm}{2.8cm}}
 \renewcommand*\l@table{\TableITA@dottedtocline{1}{0cm}{2.8cm}}
 

--- a/ita.cls
+++ b/ita.cls
@@ -120,7 +120,6 @@
 %===============================================================================
 % Check TeX engine used to compile the document and add distro specific packages
 %===============================================================================
-
 % Comandos de verificação de engine de tex usada, ex: pdfTex, XeTex, LuaTex
 \RequirePackage{iftex}
 
@@ -166,7 +165,6 @@
 %===============================================================================
 % Pacotes extras necessários para a classe ita
 %===============================================================================
-
 \RequirePackage{csquotes}    % Pacote para aspas "automáticas"
 \RequirePackage{hyphenat}    % Controles de hifenização
 \RequirePackage{setspace}    % Configura espaçamento de linhas
@@ -186,7 +184,6 @@
 %===============================================================================
 % Dimensões padrão de páginas
 %===============================================================================
-
 % Dimensões das páginas
 \geometry{a4paper,
           %showframe,  % Used only to debug margin settings
@@ -243,7 +240,6 @@
 %===============================================================================
 % Formatação ABNT para citações
 %===============================================================================
-
 % O ABNTeX2 usa o pacote `natbib` para montar referências no estilo ABNT
 % O `natbib` está ficnado obsoleto embora ainda seja usado por algumas revistas
 \RequirePackage[alf,
@@ -263,7 +259,6 @@
 %===============================================================================
 % Pacotes extras recomendados para teses
 %===============================================================================
-
 % American Mathematical Society packages
 %\RequirePackage{amsmath}     % Ambiente de matemática e equações avançado
 %\RequirePackage{amsfonts}    % Fontes p/ conjuntos: R, Z, H, etc
@@ -619,10 +614,10 @@
   \@makecippage        % Função para criar verso da folha de rosto
   \@listexaminators    % Função para criar a folha de banca
 }
+
 %===============================================================================
 % Capa de TG
 %===============================================================================
-
 \newcommand{\maketgcover}{%
   \pdfbookmark[0]{\namecover}{cover}
   \thispagestyle{empty}

--- a/main.tex
+++ b/main.tex
@@ -45,10 +45,24 @@
 %\usepackage{amssymb}     % Símbolos matemáticos
 %\usepackage{amsthm}      % Theorem writing tools
 
+% Chemistry Packages (talvez fixar a versão)
+% \usepackage{chemfig}
+% \usepackage{mhchem}
+
+% Unit Package
+%\usepackage{siunitx}     % Pacote para utilizar unidades de medida diversas
+
+% Figure Packages
 %\usepackage{epsfig}
 %\usepackage{subfig}
+
+% Table Package
 %\usepackage{multirow}
+
+% Package for Placement of Figs, Tabs, and others
 %\usepackage{float}
+
+
 
 %===============================================================================
 % Identificações (se o trabalho for em inglês, insira os dados em inglês)
@@ -120,7 +134,7 @@
 % #3 - Cidade e sigla do estado, separados por hífen. Ex: "Campinas - SP"
 \itaauthoraddress{Praça Mal Eduardo Gomes 50}
                  {12228-904}
-                 {S\~{a}o Jos\'{e} dos Campos - SP}
+                 {São José dos Campos - SP}
 
 % Titulo do Trabalho/Dissertação/Tese
 \title{Modelo Latex para TG / Dissertação / Tese do ITA}
@@ -170,6 +184,8 @@
 %\cdu{621.38}
 
 \begin{document}
+  \frontmatter  % Muda as páginas para numeração romana até aparecer o \mainmatter
+
   % Folha de Rosto e Capa para o caso do TG
   \maketitle
 

--- a/main.tex
+++ b/main.tex
@@ -66,7 +66,8 @@
 
 %===============================================================================
 % Identificações (se o trabalho for em inglês, insira os dados em inglês)
-% Para entradas abreviadas de Professora (Profa.) em português escreva: Prof$^\textnormal{a}$.
+% Para entradas abreviadas de Professora (Profa.) em português escreva:
+%     Prof$^\textnormal{a}$.
 %===============================================================================
 % Cursos de Graduação do ITA:
 % - Engenharia Aeronáutica
@@ -185,7 +186,6 @@
 
 \begin{document}
   \frontmatter  % Muda as páginas para numeração romana até aparecer o \mainmatter
-
   % Folha de Rosto e Capa para o caso do TG
   \maketitle
 
@@ -267,7 +267,6 @@
   %=============================================================================
   % Definição da Folha de Registro do Documento (FRD)
   %=============================================================================
-
   % Valores dos campos da FRD
 
   % Data do registro do documento

--- a/texts/cap0/abreviaturas.tex
+++ b/texts/cap0/abreviaturas.tex
@@ -1,4 +1,4 @@
-\begin{xltabular}{\textwidth}{l X}
+\begin{longtable}{p{0.15\textwidth} p{0.80\textwidth}}
     CTq    & computed torque                     \\
     DAC    & digital analog converter            \\
     DC     & direct current                      \\
@@ -12,4 +12,4 @@
     PTP    & point to point                      \\
     UARMII & Underactuated Robot Manipulator II  \\
     VSC    & variable structure control          \\
-\end{xltabular}
+\end{longtable}

--- a/texts/cap0/simbolos.tex
+++ b/texts/cap0/simbolos.tex
@@ -1,12 +1,19 @@
-\begin{xltabular}{\textwidth}{l X}
+%% Disclaimer:
+%%  A lista de símbolos deve ser ordenada de forma alfabética
+%%  Letras gregas também tem uma ordem "alfabética"
+
+
+\begin{longtable}{p{0.15\textwidth} p{0.80\textwidth}}
+    % List of Latin Symbols =============================================================================== %
+    % Change the subtitle name here %
+    \multicolumn{2}{l}{\textbf{Latin Symbols}} \\
+    \tabularnewline
     $a$              & Distância                                                               \\
     $\textbf{a}$     & Vetor de distâncias                                                     \\
     $\textbf{e}_{j}$ & Vetor unitário de dimensão $n$ e com o $j$-ésimo componente igual a $1$ \\
     $\textbf{K}$     & Matriz de rigidez                                                       \\
     $m_1$            & Massa do cumpim                                                         \\
-    $\delta_{k-k_f}$ & Delta de Kronecker no instante $k_f$                                    \\
     $[x]$            & dimensão do vetor x                                                     \\
-    $\sigma_{i}(A)$  & $i$-ésimo valor singular da matriz A                                    \\
     $A^{\#}$         & pseudo-inversa da matriz A                                              \\
     $(A)_{i}$        & $i$-ésima cluna da matriz A                                             \\
     $m_{i}$          & massa do $i$-ésimo link                                                 \\
@@ -16,47 +23,69 @@
     $J$              & matriz Jacobiana                                                        \\
     $M$              & matriz de inércia                                                       \\
     $W$              & inversa da matriz de inércia                                            \\
-    $C$              & matriz de Coriolis e forças centrífugas                                 \\
-    $G$              & vetor de forças gravitacionais                                          \\
+
+
+
+
+
+
+
+
+
+
+    % List of Greek Symbols =============================================================================== %
+    \tabularnewline
+    \tabularnewline
+    \tabularnewline
+    % Change the subtitle name here %
+    \multicolumn{2}{l}{\textbf{Greek Symbols}} \\
+    \tabularnewline
+    $\delta_{k-k_f}$ & Delta de Kronecker no instante $k_f$                                    \\
+    $\sigma_{i}(A)$  & $i$-ésimo valor singular da matriz A                                    \\
     $\rho_{\tau}$    & índice de acoplamento de torque                                         \\
-    $a$              & Distância                                                               \\
-    $\textbf{a}$     & Vetor de distâncias                                                     \\
-    $\textbf{e}_{j}$ & Vetor unitário de dimensão $n$ e com o $j$-ésimo componente igual a $1$ \\
-    $\textbf{K}$     & Matriz de rigidez                                                       \\
-    $m_1$            & Massa do cumpim                                                         \\
-    $\delta_{k-k_f}$ & Delta de Kronecker no instante $k_f$                                    \\
-    $[x]$            & dimensão do vetor x                                                     \\
-    $\sigma_{i}(A)$  & $i$-ésimo valor singular da matriz A                                    \\
-    $A^{\#}$         & pseudo-inversa da matriz A                                              \\
-    $(A)_{i}$        & $i$-ésima cluna da matriz A                                             \\
-    $m_{i}$          & massa do $i$-ésimo link                                                 \\
-    $I_{i}$          & inércia do $i$-ésimo link                                               \\
-    $l_{i}$          & comprimento do $i$-ésimo link                                           \\
-    $lc_{i}$         & distância entre a $i$-ésima junta e o centro de massa do $i$-ésimo link \\
-    $J$              & matriz Jacobiana                                                        \\
-    $M$              & matriz de inércia                                                       \\
-    $W$              & inversa da matriz de inércia                                            \\
-    $C$              & matriz de Coriolis e forças centrífugas                                 \\
-    $G$              & vetor de forças gravitacionais                                          \\
-    $\rho_{\tau}$    & índice de acoplamento de torque                                         \\
-    $a$              & Distância                                                               \\
-    $\textbf{a}$     & Vetor de distâncias                                                     \\
-    $\textbf{e}_{j}$ & Vetor unitário de dimensão $n$ e com o $j$-ésimo componente igual a $1$ \\
-    $\textbf{K}$     & Matriz de rigidez                                                       \\
-    $m_1$            & Massa do cumpim                                                         \\
-    $\delta_{k-k_f}$ & Delta de Kronecker no instante $k_f$                                    \\
-    $[x]$            & dimensão do vetor x                                                     \\
-    $\sigma_{i}(A)$  & $i$-ésimo valor singular da matriz A                                    \\
-    $A^{\#}$         & pseudo-inversa da matriz A                                              \\
-    $(A)_{i}$        & $i$-ésima cluna da matriz A                                             \\
-    $m_{i}$          & massa do $i$-ésimo link                                                 \\
-    $I_{i}$          & inércia do $i$-ésimo link                                               \\
-    $l_{i}$          & comprimento do $i$-ésimo link                                           \\
-    $lc_{i}$         & distância entre a $i$-ésima junta e o centro de massa do $i$-ésimo link \\
-    $J$              & matriz Jacobiana                                                        \\
-    $M$              & matriz de inércia                                                       \\
-    $W$              & inversa da matriz de inércia                                            \\
-    $C$              & matriz de Coriolis e forças centrífugas                                 \\
-    $G$              & vetor de forças gravitacionais                                          \\
-    $\rho_{\tau}$    & índice de acoplamento de torque
-\end{xltabular}
+
+
+
+
+
+
+
+
+    % List of Special Symbols ============================================================================= %
+    \tabularnewline
+    \tabularnewline
+    \tabularnewline
+    % Change the subtitle name here %
+    \multicolumn{2}{l}{\textbf{Special Symbols}} \\
+    \tabularnewline
+    \( \mathcal{C} \)    & Alguma coisa que você tenha inventado. \\
+
+
+
+
+
+
+
+    % List of Subscripts ================================================================================== %
+    \tabularnewline
+    \tabularnewline
+    \tabularnewline
+    % Change the subtitle name here %
+    \multicolumn{2}{l}{\textbf{Subscripts}} \\
+    \tabularnewline
+    $i$                 & índice de alguma coisa de seu interesse                                         \\
+
+
+
+
+
+
+    % List of Superscripts ================================================================================ %
+    \tabularnewline
+    \tabularnewline
+    \tabularnewline
+    % Change the subtitle name here %
+    \multicolumn{2}{l}{\textbf{Superscripts}} \\
+    \tabularnewline
+    $\#$         & simbolo de pseudo-inversa da matriz A                                              \\
+\end{longtable}


### PR DESCRIPTION
I improved, in my opinion, the definition of the List of Abbreviations and Acronyms and the List of Symbols.

Moreover, I corrected the position of the "--" separating the Figure or Table number and its title in the List of Figures and Tables.

Finally, I added the command \frontmatter that changes the page numbering before the command \mainmatter in the book class. This switches the page numbering to lowercase roman numbers instead of "normal" numbering scheme.