### PR TITLE
Tikz support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@
 #
 # Mantenha sincronizado com o valor em .gitignore
 OUT_DIR ?= build
+TKZ_DIR ?= $(OUT_DIR)/tikz
 
 # Opções passadas para latexmk.
-LATEXMK_FLAGS ?= -xelatex --synctex=1
+LATEXMK_FLAGS ?= -xelatex -shell-escape --synctex=1
 
+TKZ_SRCS := $(shell find . -type f -name "*.tikz.tex")	# This extension can change
 TEX_SRCS := $(shell find . -type f -name "*.tex")
 BIB_SRCS := $(shell find . -type f -name "*.bib")
 IMG_SRCS := $(shell find . -type f -name "*.jpg" -or -name "*.png" -or -name "*.eps")
@@ -18,6 +20,8 @@ all: compile copy
 .PHONY: all
 
 compile: $(SRCS)
+	@mkdir -p $(OUT_DIR)
+	@mkdir -p $(TKZ_DIR)
 	@latexmk $(LATEXMK_FLAGS) -output-directory=$(OUT_DIR) main.tex
 	@make copy
 

--- a/main.tex
+++ b/main.tex
@@ -50,6 +50,16 @@
 %\usepackage{multirow}
 %\usepackage{float}
 
+% Talvez jogar para o ita.cls?
+\usepackage{tikz}
+\usetikzlibrary{external}
+% https://stackoverflow.com/questions/40768426/tikz-externalize-issue-when-using-pdflatex-with-output-directory
+\tikzexternalize[prefix=tikz/,shell escape={-shell-escape\space-output-directory=build}]
+% \newcommand{\inputtikz}[1]{%
+%   \tikzsetnextfilename{#1}%
+%   \input{#1.tikz}%
+% }
+
 %===============================================================================
 % Identificações (se o trabalho for em inglês, insira os dados em inglês)
 % Para entradas abreviadas de Professora (Profa.) em português escreva: Prof$^\textnormal{a}$.

--- a/texts/cap4/capitulo4.tex
+++ b/texts/cap4/capitulo4.tex
@@ -2,10 +2,23 @@
 
 Caros amigos, a adoção de políticas descentralizadoras possibilita uma melhor visão global do levantamento das variáveis envolvidas. Nunca é demais lembrar o peso e o significado destes problemas, uma vez que a determinação clara de objetivos oferece uma interessante oportunidade para verificação das diretrizes de desenvolvimento para o futuro. Assim mesmo, a percepção das dificuldades cumpre um papel essencial na formulação do sistema de participação geral. Evidentemente, o desenvolvimento contínuo de distintas formas de atuação agrega valor ao estabelecimento das posturas dos órgãos dirigentes com relação às suas atribuições. Do mesmo modo, o novo modelo estrutural aqui preconizado auxilia a preparação e a composição do retorno esperado a longo prazo.
 
-          Ainda assim, existem dúvidas a respeito de como a consolidação das estruturas deve passar por modificações independentemente de todos os recursos funcionais envolvidos. Podemos já vislumbrar o modo pelo qual a complexidade dos estudos efetuados facilita a criação do sistema de formação de quadros que corresponde às necessidades. Por outro lado, o consenso sobre a necessidade de qualificação prepara-nos para enfrentar situações atípicas decorrentes das novas proposições.
+Ainda assim, existem dúvidas a respeito de como a consolidação das estruturas deve passar por modificações independentemente de todos os recursos funcionais envolvidos. Podemos já vislumbrar o modo pelo qual a complexidade dos estudos efetuados facilita a criação do sistema de formação de quadros que corresponde às necessidades. Por outro lado, o consenso sobre a necessidade de qualificação prepara-nos para enfrentar situações atípicas decorrentes das novas proposições.
 
-          Acima de tudo, é fundamental ressaltar que o início da atividade geral de formação de atitudes obstaculiza a apreciação da importância dos índices pretendidos. A prática cotidiana prova que o entendimento das metas propostas acarreta um processo de reformulação e modernização dos níveis de motivação departamental. Não obstante, o aumento do diálogo entre os diferentes setores produtivos garante a contribuição de um grupo importante na determinação das formas de ação. Todas estas questões, devidamente ponderadas, levantam dúvidas sobre se o comprometimento entre as equipes representa uma abertura para a melhoria da gestão inovadora da qual fazemos parte.
 
-          Pensando mais a longo prazo, a mobilidade dos capitais internacionais promove a alavancagem do processo de comunicação como um todo. Desta maneira, a hegemonia do ambiente político talvez venha a ressaltar a relatividade das diversas correntes de pensamento. O cuidado em identificar pontos críticos na expansão dos mercados mundiais exige a precisão e a definição dos procedimentos normalmente adotados. Gostaria de enfatizar que o desafiador cenário globalizado maximiza as possibilidades por conta do impacto na agilidade decisória.
+% TikZ Picture Example
+\begin{figure}[htbp]
+    \centering
+    % TikZ Fig Name (Easy to find in build/tikz)
+    \tikzsetnextfilename{abstraction_layers}
+    % TikZ Fig Input
+    \input{texts/cap4/figs/abstraction_layers.tikz.tex} 
+    \caption{TikZ example.}
+    \label{fig:name}
+\end{figure}
 
-          Todavia, a crescente influência da mídia pode nos levar a considerar a reestruturação do fluxo de informações. O empenho em analisar a necessidade de renovação processual desafia a capacidade de equalização dos modos de operação convencionais. Neste sentido, a competitividade nas transações comerciais causa impacto indireto na reavaliação de alternativas às soluções ortodoxas.
+
+Acima de tudo, é fundamental ressaltar que o início da atividade geral de formação de atitudes obstaculiza a apreciação da importância dos índices pretendidos. A prática cotidiana prova que o entendimento das metas propostas acarreta um processo de reformulação e modernização dos níveis de motivação departamental. Não obstante, o aumento do diálogo entre os diferentes setores produtivos garante a contribuição de um grupo importante na determinação das formas de ação. Todas estas questões, devidamente ponderadas, levantam dúvidas sobre se o comprometimento entre as equipes representa uma abertura para a melhoria da gestão inovadora da qual fazemos parte.
+
+Pensando mais a longo prazo, a mobilidade dos capitais internacionais promove a alavancagem do processo de comunicação como um todo. Desta maneira, a hegemonia do ambiente político talvez venha a ressaltar a relatividade das diversas correntes de pensamento. O cuidado em identificar pontos críticos na expansão dos mercados mundiais exige a precisão e a definição dos procedimentos normalmente adotados. Gostaria de enfatizar que o desafiador cenário globalizado maximiza as possibilidades por conta do impacto na agilidade decisória.
+
+Todavia, a crescente influência da mídia pode nos levar a considerar a reestruturação do fluxo de informações. O empenho em analisar a necessidade de renovação processual desafia a capacidade de equalização dos modos de operação convencionais. Neste sentido, a competitividade nas transações comerciais causa impacto indireto na reavaliação de alternativas às soluções ortodoxas.

--- a/texts/cap4/figs/abstraction_layers.tikz.tex
+++ b/texts/cap4/figs/abstraction_layers.tikz.tex
@@ -1,0 +1,32 @@
+
+\begin{tikzpicture}{}
+    \tikzstyle{every node}=[align=center];
+    \tikzstyle{block} = [thick, rounded corners=2mm, draw, minimum width = 2cm, minimum height = 1cm]
+    \tikzstyle{flow} = [->, thick, >= latex, rounded corners=2mm]
+
+    \node[block, fill=green!15, draw=green] (Model) at (0.5,3) {Models \\ (MoCs)};
+    \node[block, fill=orange!25, draw=orange] (VHDL) at (-1,1) {HDL};
+    \node[block, fill=orange!25, draw=orange] (C) at (2,1) {SW Code};
+    \node[block, fill=orange!15, draw=orange] (FPGABitstream) at (-2,-1) {FPGA \\ Bitstream};
+    \node[block, fill=orange!15, draw=orange] (StandardCell) at (0.5,-1) {Standard \\ Cells};
+    \node[block, fill=orange!15, draw=orange] (CPUArch) at (3,-1) {x86, ARM, \\ RISC-V asm};
+    \node[block, fill=blue!20, draw=blue] (FPGA) at (-2,-3) {FPGA};
+    \node[block, fill=blue!20, draw=blue] (ASIC) at (0.5,-3) {ASIC};
+    \node[block, fill=blue!20, draw=blue] (CPU) at (3,-3) {CPU, GPU, \\ DSP};
+
+    \draw[flow] (Model) -- (VHDL);
+    \draw[flow] (Model) -- (C);
+    \draw[flow] (VHDL) -- (FPGABitstream);
+    \draw[flow] (VHDL) -- (StandardCell);
+    \draw[flow] (C) -- (CPUArch);
+    \draw[flow] (FPGABitstream) -- (FPGA);
+    \draw[flow] (StandardCell) -- (ASIC);
+    \draw[flow] (CPUArch) -- (CPU);
+
+    %\draw [dashed] (-4,4) -- (6,4);
+    \draw [dashed] (-4,0) -- (6,0) node[above left] {Programs};
+    \draw [dashed] (-4,-2) -- (6,-2) node[above left] {Executable};
+    \draw [dashed] (-4,2) -- (6,2) node[above left] {Models};
+    \draw [dashed] (-4,-4) -- (6,-4) node[above left] {Silicon};
+
+\end{tikzpicture}


### PR DESCRIPTION
I added support for TikZ figures to be compiled using the built-in external keyword from the TikZ package. This approach saves the TikZ images in the "build/tikz" directory to be reused by the LaTeX compiler. Moreover, you can assign a name to the created figure to track the file in the "build/tikz" directory. There are some improvements that can be done, but I wanted to share the implementation first.